### PR TITLE
build: install native dependencies for image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:20-alpine
 
 # Ensure native deps work smoothly
-RUN apk add --no-cache python3 make g++ git
+RUN apk add --no-cache python3 make g++ git libc6-compat vips-dev fftw-dev
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- install python3, build tools, git, libc6-compat and image libs in Docker build

## Testing
- `yarn build` *(fails: Failed to fetch DM Sans from Google Fonts)*
- `/kaniko/executor --context $PWD --dockerfile Dockerfile --no-push` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689fe2848520833086cddfd97c67b6bb