### PR TITLE
Fix Kaniko build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@ npm-debug.log
 .git
 .gitignore
 README.md
-Dockerfile
 .dockerignore
 .env.local
 .env.development.local


### PR DESCRIPTION
## Summary
- ensure Dockerfile is not ignored so Kaniko can access it during build

## Testing
- `yarn lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689fe55bf28c8330a2744b7ddbe23ba8