### PR TITLE
Disable Next.js telemetry for offline start

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,7 @@
 // Load environment variables first
 require('dotenv').config({ path: require('path').join(__dirname, '.env') })
+// Disable Next.js telemetry and version checks to allow offline environments
+process.env.NEXT_TELEMETRY_DISABLED = '1'
 
 // Log environment loading
 console.log('🔍 Environment variables loaded:')


### PR DESCRIPTION
## Summary
- prevent Next.js dev server from crashing offline by disabling telemetry/version checks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68a030e34e088330818fe315e4137cf4